### PR TITLE
Implemented end of day and travel back to home connector

### DIFF
--- a/lib/components/tilelist/dailyView/dailyTileList.dart
+++ b/lib/components/tilelist/dailyView/dailyTileList.dart
@@ -15,11 +15,20 @@ import 'package:tiler_app/data/subCalendarEvent.dart';
 import 'package:tiler_app/data/tilerEvent.dart';
 import 'package:tiler_app/data/timeline.dart';
 import 'package:tiler_app/services/analyticsSignal.dart';
+import 'package:tiler_app/services/api/settingsApi.dart';
 import 'package:tiler_app/theme/tile_theme.dart';
 import 'package:tiler_app/util.dart';
 import 'package:tuple/tuple.dart';
 import 'package:tiler_app/constants.dart' as Constants;
 import 'package:tiler_app/l10n/app_localizations.dart';
+
+/// Combines a [day] date with a [timeOfDay] to produce a [DateTime] on that
+/// day at the given time. Returns null when [timeOfDay] is null.
+DateTime? endOfDayDateTimeFor(DateTime day, TimeOfDay? timeOfDay) {
+  if (timeOfDay == null) return null;
+  return DateTime(
+      day.year, day.month, day.day, timeOfDay.hour, timeOfDay.minute);
+}
 
 class DailyTileList extends TileList {
   static final String routeName = '/DailyTileList';
@@ -52,6 +61,9 @@ class _DailyTileListState extends TileListState {
   bool _isLoadingPastDays = false;
   bool _isLoadingFutureDays = false;
 
+  /// User's configured end-of-day time, fetched once from settings on init.
+  TimeOfDay? _userEndOfDay;
+
   @override
   void initState() {
     super.initState();
@@ -60,6 +72,30 @@ class _DailyTileListState extends TileListState {
         Duration(days: 7));
     incrementalTilerScrollId = "incremental-get-schedule";
     previousTimeline = this.timeLine;
+    _fetchUserEndOfDay();
+  }
+
+  void _fetchUserEndOfDay() {
+    final api = SettingsApi(getContextCallBack: () => context);
+    api.getUserStartOfDay().then((startOfDay) {
+      if (mounted) {
+        setState(() {
+          _userEndOfDay = startOfDay.timeOfDay ?? Utility.defaultEndOfDay;
+        });
+      }
+    }).catchError((_) {
+      if (mounted) {
+        setState(() {
+          _userEndOfDay = Utility.defaultEndOfDay;
+        });
+      }
+    });
+  }
+
+  /// Returns the end-of-day [DateTime] for the day identified by [dayIndex].
+  DateTime? _endOfDayFor(int dayIndex) {
+    final day = Utility.getTimeFromIndex(dayIndex);
+    return endOfDayDateTimeFor(day, _userEndOfDay);
   }
 
   String _generateIncrementalIdToMapping() {
@@ -292,6 +328,8 @@ class _DailyTileListState extends TileListState {
             showEnhancedCards: true,
             showTravelConnectors: true,
             showTimelineMarkers: true,
+            endOfDayTime: _endOfDayFor(dayIndex),
+            onEndOfDayUpdated: _fetchUserEndOfDay,
           );
           upcomingDayTilesDict[dayIndex] = upcomingTileBatch;
         }
@@ -310,6 +348,8 @@ class _DailyTileListState extends TileListState {
             showEnhancedCards: true,
             showTravelConnectors: true,
             showTimelineMarkers: true,
+            endOfDayTime: _endOfDayFor(dayIndex),
+            onEndOfDayUpdated: _fetchUserEndOfDay,
           );
           precedingDayTilesDict[dayIndex] = precedingDayTileBatch;
         }
@@ -333,6 +373,8 @@ class _DailyTileListState extends TileListState {
     return EnhancedWithinNowBatch(
       key: ValueKey("_enhanced_within_now_0"),
       tiles: [...elapsedTiles, ...notElapsedTiles],
+      endOfDayTime: _endOfDayFor(Utility.currentTime().universalDayIndex),
+      onEndOfDayUpdated: _fetchUserEndOfDay,
     );
   }
 
@@ -385,6 +427,8 @@ class _DailyTileListState extends TileListState {
       EnhancedWithinNowBatch emptyTodayBatch = EnhancedWithinNowBatch(
         key: ValueKey("_enhanced_within_now_empty"),
         tiles: [],
+        endOfDayTime: _endOfDayFor(currentTime.universalDayIndex),
+        onEndOfDayUpdated: _fetchUserEndOfDay,
       );
       Widget widget = Container(
         height: MediaQuery.of(context).size.height,

--- a/lib/components/tilelist/dailyView/enhancedTileBatch.dart
+++ b/lib/components/tilelist/dailyView/enhancedTileBatch.dart
@@ -39,6 +39,8 @@ class EnhancedTileBatch extends StatefulWidget {
   final bool showConflictAlerts;
   final bool preview;
   final String? selectedActionEntityId;
+  final DateTime? endOfDayTime;
+  final VoidCallback? onEndOfDayUpdated;
   const EnhancedTileBatch({
     this.dayIndex,
     this.tiles,
@@ -52,6 +54,8 @@ class EnhancedTileBatch extends StatefulWidget {
     this.showConflictAlerts = true,
     this.preview = false,
     this.selectedActionEntityId,
+    this.endOfDayTime,
+    this.onEndOfDayUpdated,
     Key? key,
   }) : super(key: key);
 
@@ -243,6 +247,8 @@ class EnhancedTileBatchState extends State<EnhancedTileBatch> {
       excludeDeclinedFromConflicts: false,
       now: DateTime.now(),
       selectedActionEntityId: widget.selectedActionEntityId,
+      endOfDayTime: widget.endOfDayTime,
+      onEndOfDayUpdated: widget.onEndOfDayUpdated,
       buildTile: (tile,
           {required hour, required showHourMarker, required isCurrentHour}) {
         if (widget.showTimelineMarkers) {

--- a/lib/components/tilelist/dailyView/enhancedWithinNowBatch.dart
+++ b/lib/components/tilelist/dailyView/enhancedWithinNowBatch.dart
@@ -37,12 +37,16 @@ class EnhancedWithinNowBatch extends TileBatch {
   EnhancedWithinNowBatchState? _state;
   final String? selectedActionEntityId;
   final bool preview;
+  final DateTime? endOfDayTime;
+  final VoidCallback? onEndOfDayUpdated;
   EnhancedWithinNowBatch({
     List<TilerEvent>? tiles,
     TimelineSummary? dayData,
     Timeline? sleepTimeline,
     this.preview = false,
     this.selectedActionEntityId,
+    this.endOfDayTime,
+    this.onEndOfDayUpdated,
     Key? key,
   }) : super(
           key: key,
@@ -187,8 +191,11 @@ class EnhancedWithinNowBatchState extends TileBatchState {
         subEvent: tile,
         initiallyExpanded: isTutorialCurrent,
         preview: (widget as EnhancedWithinNowBatch).preview,
-        hasDottedBorder: (widget as EnhancedWithinNowBatch).selectedActionEntityId != null &&
-            tile.id?.contains((widget as EnhancedWithinNowBatch).selectedActionEntityId!) == true,
+        hasDottedBorder:
+            (widget as EnhancedWithinNowBatch).selectedActionEntityId != null &&
+                tile.id?.contains((widget as EnhancedWithinNowBatch)
+                        .selectedActionEntityId!) ==
+                    true,
       );
       if (isTutorialCurrent) {
         return Container(
@@ -198,11 +205,13 @@ class EnhancedWithinNowBatchState extends TileBatchState {
       }
       return card;
     }
-    return TileWidget(tile,preview: (widget as EnhancedWithinNowBatch).preview);
+    return TileWidget(tile,
+        preview: (widget as EnhancedWithinNowBatch).preview);
   }
 
   /// Build tiles list with travel connectors and conflict handling
- ( List<Widget>, int?) _buildTilesWithConnectors(List<TilerEvent> orderedTiles) {
+  (List<Widget>, int?) _buildTilesWithConnectors(
+      List<TilerEvent> orderedTiles) {
     final withinNow = widget as EnhancedWithinNowBatch;
     final result = buildTileListWithConnectors(
       orderedTiles: orderedTiles,
@@ -211,7 +220,10 @@ class EnhancedWithinNowBatchState extends TileBatchState {
       excludeDeclinedFromConflicts: true,
       now: DateTime.now(),
       selectedActionEntityId: withinNow.selectedActionEntityId,
-      buildTile: (tile, {required hour, required showHourMarker, required isCurrentHour}) {
+      endOfDayTime: withinNow.endOfDayTime,
+      onEndOfDayUpdated: withinNow.onEndOfDayUpdated,
+      buildTile: (tile,
+          {required hour, required showHourMarker, required isCurrentHour}) {
         return TileRowWithHourMarker(
           hour: hour,
           showHourMarker: showHourMarker,
@@ -220,7 +232,8 @@ class EnhancedWithinNowBatchState extends TileBatchState {
           child: _buildTileWidget(tile),
         );
       },
-      buildConflictGroup: (group, {required hour, required showHourMarker, required isCurrentHour}) {
+      buildConflictGroup: (group,
+          {required hour, required showHourMarker, required isCurrentHour}) {
         return TileRowWithHourMarker(
           hour: hour,
           showHourMarker: showHourMarker,
@@ -432,7 +445,8 @@ class EnhancedWithinNowBatchState extends TileBatchState {
           onExtendedTap: () {
             CombinedAlertsBannerHelpers.showExtendedTilesModal(
                 preview: (widget as EnhancedWithinNowBatch).preview,
-                context, extendedTiles);
+                context,
+                extendedTiles);
           },
           pendingRsvpTiles: pendingRsvpTiles,
           declinedTiles: declinedTiles,
@@ -492,8 +506,10 @@ class EnhancedWithinNowBatchState extends TileBatchState {
     Widget tilesContent;
     if (viableTiles.isNotEmpty) {
       final orderedTiles = Utility.orderTiles(viableTiles.values.toList());
-      final (tilesWithConnectors, targetScrollIndex)= _buildTilesWithConnectors(orderedTiles);
-      if ((widget as EnhancedWithinNowBatch).preview && targetScrollIndex != null) {
+      final (tilesWithConnectors, targetScrollIndex) =
+          _buildTilesWithConnectors(orderedTiles);
+      if ((widget as EnhancedWithinNowBatch).preview &&
+          targetScrollIndex != null) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           _listController.jumpToItem(
             index: targetScrollIndex!,
@@ -506,10 +522,11 @@ class EnhancedWithinNowBatchState extends TileBatchState {
       tilesContent = SuperSliverList(
         listController: _listController,
         delegate: SliverChildBuilderDelegate(
-              (context, index) {
-            if (index == tilesWithConnectors.length) return MediaQuery.of(context).orientation == Orientation.landscape
-                ? TileDimensions.bottomLandScapePaddingForTileBatchListOfTiles
-                : TileDimensions.bottomPortraitPaddingForTileBatchListOfTiles;
+          (context, index) {
+            if (index == tilesWithConnectors.length)
+              return MediaQuery.of(context).orientation == Orientation.landscape
+                  ? TileDimensions.bottomLandScapePaddingForTileBatchListOfTiles
+                  : TileDimensions.bottomPortraitPaddingForTileBatchListOfTiles;
             return tilesWithConnectors[index];
           },
           childCount: tilesWithConnectors.length + 1,

--- a/lib/components/tilelist/dailyView/previewDailyTileList.dart
+++ b/lib/components/tilelist/dailyView/previewDailyTileList.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:tiler_app/bloc/vibeChat/vibe_chat_bloc.dart';
 import 'package:tiler_app/components/PendingWidget.dart';
+import 'package:tiler_app/components/tilelist/dailyView/dailyTileList.dart';
 import 'package:tiler_app/components/tilelist/dailyView/enhancedTileBatch.dart';
 import 'package:tiler_app/components/tilelist/dailyView/enhancedWithinNowBatch.dart';
 import 'package:tiler_app/components/tilelist/tileList.dart';
@@ -12,17 +13,13 @@ import 'package:tiler_app/data/timeline.dart';
 
 class PreviewDailyTileList extends TileList {
   final DateTime displayDate;
-  PreviewDailyTileList({
-    Key? key,
-    required this.displayDate
-  }) : super(key: key);
+  PreviewDailyTileList({Key? key, required this.displayDate}) : super(key: key);
 
   @override
   _PreviewDailyTileListState createState() => _PreviewDailyTileListState();
 }
 
 class _PreviewDailyTileListState extends TileListState {
-
   @override
   PreviewDailyTileList get widget => super.widget as PreviewDailyTileList;
 
@@ -53,7 +50,9 @@ class _PreviewDailyTileListState extends TileListState {
         key: ValueKey("today_batch"),
         tiles: [...elapsedTiles, ...upcomingTiles],
         preview: true,
-        selectedActionEntityId: context.read<VibeChatBloc>().state.selectedActionEntityId
+        selectedActionEntityId:
+            context.read<VibeChatBloc>().state.selectedActionEntityId,
+        endOfDayTime: endOfDayDateTimeFor(now, Utility.defaultEndOfDay),
       );
     } else {
       int dayIndex = Utility.getDayIndex(widget.displayDate);
@@ -66,7 +65,10 @@ class _PreviewDailyTileListState extends TileListState {
         showTravelConnectors: true,
         showTimelineMarkers: true,
         preview: true,
-        selectedActionEntityId: context.read<VibeChatBloc>().state.selectedActionEntityId
+        selectedActionEntityId:
+            context.read<VibeChatBloc>().state.selectedActionEntityId,
+        endOfDayTime:
+            endOfDayDateTimeFor(widget.displayDate, Utility.defaultEndOfDay),
       );
     }
   }
@@ -75,12 +77,12 @@ class _PreviewDailyTileListState extends TileListState {
   Widget build(BuildContext context) {
     return BlocBuilder<VibeChatBloc, VibeChatState>(
       builder: (context, state) {
-        final tiles = (state.previewTiles ?? []).where((tile) =>
-            tile.isInterfering(Timeline.fromDateTime(
-              widget.displayDate.dayDate,
-              widget.displayDate.dayDate.add(Duration(days: 1)),
-            ))
-        ).toList();
+        final tiles = (state.previewTiles ?? [])
+            .where((tile) => tile.isInterfering(Timeline.fromDateTime(
+                  widget.displayDate.dayDate,
+                  widget.displayDate.dayDate.add(Duration(days: 1)),
+                )))
+            .toList();
         return Container(
           height: MediaQuery.of(context).size.height,
           decoration: BoxDecoration(color: colorScheme.surfaceContainerLowest),
@@ -91,7 +93,6 @@ class _PreviewDailyTileListState extends TileListState {
       },
     );
   }
-
 
   @override
   void dispose() {

--- a/lib/components/tilelist/dailyView/tileConnectorLayout.dart
+++ b/lib/components/tilelist/dailyView/tileConnectorLayout.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:tiler_app/components/tilelist/conflictAlert.dart';
+import 'package:tiler_app/components/tilelist/returnConnector.dart';
 import 'package:tiler_app/components/tilelist/travelConnector.dart';
 import 'package:tiler_app/data/subCalendarEvent.dart';
 import 'package:tiler_app/data/tilerEvent.dart';
@@ -47,6 +48,8 @@ TileConnectorLayoutResult buildTileListWithConnectors({
   required bool excludeDeclinedFromConflicts,
   required DateTime now,
   String? selectedActionEntityId,
+  DateTime? endOfDayTime,
+  VoidCallback? onEndOfDayUpdated,
   required TileWidgetBuilder buildTile,
   required ConflictGroupWidgetBuilder buildConflictGroup,
   required ConnectorWrapper wrapConnector,
@@ -177,6 +180,18 @@ TileConnectorLayoutResult buildTileListWithConnectors({
     if (tile is SubCalendarEvent) {
       prevRenderedTile = tile;
     }
+  }
+
+  // Always emit a ReturnConnector after the last tile — it shows end-of-day
+  // even when there is no return-travel data.
+  if (showTravelConnectors && prevRenderedTile != null) {
+    widgets.add(wrapConnector(
+      ReturnConnector(
+        lastTile: prevRenderedTile,
+        endOfDayTime: endOfDayTime,
+        onEndOfDayUpdated: onEndOfDayUpdated,
+      ),
+    ));
   }
 
   return TileConnectorLayoutResult(

--- a/lib/components/tilelist/returnConnector.dart
+++ b/lib/components/tilelist/returnConnector.dart
@@ -1,0 +1,397 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:tiler_app/data/executionEnums.dart';
+import 'package:tiler_app/data/location.dart';
+import 'package:tiler_app/data/subCalendarEvent.dart';
+import 'package:tiler_app/data/travelDetail.dart';
+import 'package:tiler_app/l10n/app_localizations.dart';
+import 'package:tiler_app/routes/authenticatedUser/settings/tilePreferences/tilePreferences.dart';
+import 'package:tiler_app/theme/tile_colors.dart';
+import 'package:tiler_app/theme/tile_text_styles.dart';
+import 'package:tiler_app/util.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// Rendered after the last tile in the day list.
+///
+/// Two visual sections stacked vertically:
+///   1. **Travel section** (optional) — only when return-travel data is present.
+///      Tappable: launches Google Maps for non-home destinations.
+///      Consistent visual language with [TravelConnector] (gradient line + circle icon).
+///   2. **End-of-day marker** (always shown) — sunset gradient icon + "End of Day"
+///      label with optional time. Signals day conclusion rather than just a label.
+class ReturnConnector extends StatelessWidget {
+  final SubCalendarEvent lastTile;
+
+  /// The user's configured end-of-day time.  When provided, the time is shown
+  /// below the "End of Day" label in the sunset marker.
+  final DateTime? endOfDayTime;
+
+  /// Called after returning from the TilePreferencesScreen so the parent can
+  /// re-fetch the latest end-of-day setting.
+  final VoidCallback? onEndOfDayUpdated;
+
+  // Sunset palette — warm amber → deep purple
+  static const Color _sunsetAmber = Color(0xFFFF8F00);
+  static const Color _sunsetPurple = Color(0xFF6A1B9A);
+
+  const ReturnConnector({
+    Key? key,
+    required this.lastTile,
+    this.endOfDayTime,
+    this.onEndOfDayUpdated,
+  }) : super(key: key);
+
+  // ---------------------------------------------------------------------------
+  // Data helpers
+  // ---------------------------------------------------------------------------
+
+  TravelData? get _afterData => lastTile.travelDetail?.after;
+
+  double? get _durationMs {
+    final fromDetail = _afterData?.duration;
+    if (fromDetail != null) return fromDetail;
+    return lastTile.travelTimeAfter;
+  }
+
+  bool get _isHome {
+    final desc = _afterData?.endLocation?.description;
+    return desc?.toLowerCase() == Location.homeLocationNickName;
+  }
+
+  bool get _hasLocation => _afterData?.endLocation != null;
+
+  bool get _hasTravelData =>
+      lastTile.travelDetail?.after != null || lastTile.travelTimeAfter != null;
+
+  bool get _canOpenMaps =>
+      _hasLocation &&
+      !_isHome &&
+      (_afterData!.endLocation!.isNotNullAndNotDefault);
+
+  TravelMedium get _travelMode =>
+      TravelMediumExtension.fromString(_afterData?.travelMedium);
+
+  String _formatDuration(double ms) {
+    final minutes = (ms / 60000).round();
+    if (minutes < 60) return '$minutes min';
+    final hours = minutes ~/ 60;
+    final remaining = minutes % 60;
+    return remaining == 0 ? '${hours}h' : '${hours}h ${remaining}m';
+  }
+
+  String _formatTime(DateTime dt) => DateFormat.jm().format(dt);
+
+  Future<void> _launchMaps() async {
+    if (!_canOpenMaps) return;
+    final dest = _afterData!.endLocation!;
+    final origin = _afterData?.startLocation ?? lastTile.location;
+
+    String destination;
+    if (dest.address?.isNotEmpty == true) {
+      destination = Uri.encodeComponent(dest.address!);
+    } else {
+      destination = '${dest.latitude},${dest.longitude}';
+    }
+
+    String? originParam;
+    if (origin?.isNotNullAndNotDefault == true) {
+      if (origin!.address?.isNotEmpty == true) {
+        originParam = Uri.encodeComponent(origin.address!);
+      } else {
+        originParam = '${origin.latitude},${origin.longitude}';
+      }
+    }
+
+    final travelMode = _travelMode.googleMapsMode;
+    String url =
+        'https://www.google.com/maps/dir/?api=1&destination=$destination&travelmode=$travelMode';
+    if (originParam != null) {
+      url += '&origin=$originParam';
+    }
+
+    final uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Build
+  // ---------------------------------------------------------------------------
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (_hasTravelData) _buildTravelSection(context),
+        _buildEndOfDaySection(context),
+      ],
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Travel section
+  // ---------------------------------------------------------------------------
+
+  Widget _buildTravelSection(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final durationMs = _durationMs;
+    final hasDuration = durationMs != null && durationMs > 0;
+
+    final IconData travelIcon = _isHome ? Icons.home : _travelMode.icon;
+
+    String destinationLabel = '';
+    if (_isHome) {
+      destinationLabel = AppLocalizations.of(context)!.home;
+    } else if (_hasLocation) {
+      final loc = _afterData!.endLocation!;
+      destinationLabel = loc.description?.isNotEmpty == true
+          ? loc.description!
+          : (loc.address ?? '');
+    }
+
+    return GestureDetector(
+      onTap: _canOpenMaps ? _launchMaps : null,
+      child: Container(
+        margin: const EdgeInsets.symmetric(vertical: 2),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            // Left connector column — consistent with TravelConnector width
+            SizedBox(
+              width: 60,
+              child: Column(
+                children: [
+                  Container(
+                    width: 2,
+                    height: 16,
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: [
+                          colorScheme.outline.withOpacity(0.3),
+                          TileColors.travel.withOpacity(0.6),
+                        ],
+                      ),
+                    ),
+                  ),
+                  Container(
+                    padding: const EdgeInsets.all(6),
+                    decoration: BoxDecoration(
+                      color: TileColors.travel.withOpacity(0.15),
+                      shape: BoxShape.circle,
+                      border: Border.all(
+                        color: TileColors.travel.withOpacity(0.3),
+                        width: 1.5,
+                      ),
+                    ),
+                    child: Icon(travelIcon, size: 16, color: TileColors.travel),
+                  ),
+                  Container(
+                    width: 2,
+                    height: 16,
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: [
+                          TileColors.travel.withOpacity(0.6),
+                          _sunsetAmber.withOpacity(0.4),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            // Travel info card
+            Expanded(
+              child: Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                decoration: BoxDecoration(
+                  color: TileColors.travel.withOpacity(0.08),
+                  borderRadius: BorderRadius.circular(12),
+                  border: Border.all(
+                    color: TileColors.travel.withOpacity(0.2),
+                    width: 1,
+                  ),
+                ),
+                child: Row(
+                  children: [
+                    if (hasDuration) ...[
+                      Text(
+                        _formatDuration(durationMs),
+                        style: TextStyle(
+                          fontFamily: TileTextStyles.rubikFontName,
+                          fontSize: 14,
+                          fontWeight: FontWeight.w600,
+                          color: TileColors.travel,
+                        ),
+                      ),
+                      const SizedBox(width: 4),
+                    ],
+                    if (destinationLabel.isNotEmpty)
+                      Expanded(
+                        child: Text(
+                          destinationLabel,
+                          style: TextStyle(
+                            fontFamily: TileTextStyles.rubikFontName,
+                            fontSize: 13,
+                            color: colorScheme.onSurface.withOpacity(0.7),
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      )
+                    else
+                      const Spacer(),
+                    if (_canOpenMaps) ...[
+                      const SizedBox(width: 8),
+                      Icon(
+                        Icons.navigation_outlined,
+                        size: 16,
+                        color: TileColors.travel,
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(width: 16),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // End-of-day section — always rendered
+  // ---------------------------------------------------------------------------
+
+  Widget _buildEndOfDaySection(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 16),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          // Left: connecting line from travel section → sunset icon (terminal)
+          SizedBox(
+            width: 60,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  width: 2,
+                  height: 16,
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                      colors: [
+                        _hasTravelData
+                            ? _sunsetAmber.withOpacity(0.4)
+                            : colorScheme.outline.withOpacity(0.3),
+                        _sunsetAmber.withOpacity(0.7),
+                      ],
+                    ),
+                  ),
+                ),
+                // Sunset gradient icon pill
+                Container(
+                  width: 32,
+                  height: 32,
+                  decoration: BoxDecoration(
+                    gradient: const LinearGradient(
+                      colors: [_sunsetAmber, _sunsetPurple],
+                      begin: Alignment.topLeft,
+                      end: Alignment.bottomRight,
+                    ),
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: const Icon(
+                    Icons.wb_twilight,
+                    size: 18,
+                    color: Colors.white,
+                  ),
+                ),
+                // Fade-out trailing line — the day tapers off
+                Container(
+                  width: 2,
+                  height: 12,
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                      colors: [
+                        _sunsetPurple.withOpacity(0.4),
+                        Colors.transparent,
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          // "End of Day" label + optional time
+          Expanded(
+            child: GestureDetector(
+              onTap: () =>
+                  Navigator.pushNamed(context, TilePreferencesScreen.routeName)
+                      .then((_) => onEndOfDayUpdated?.call()),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      ShaderMask(
+                        shaderCallback: (bounds) => const LinearGradient(
+                          colors: [_sunsetAmber, _sunsetPurple],
+                          begin: Alignment.centerLeft,
+                          end: Alignment.centerRight,
+                        ).createShader(
+                            Rect.fromLTWH(0, 0, bounds.width, bounds.height)),
+                        child: Text(
+                          AppLocalizations.of(context)!.endOfDay,
+                          style: TextStyle(
+                            fontFamily: TileTextStyles.rubikFontName,
+                            fontSize: 14,
+                            fontWeight: FontWeight.w600,
+                            // ShaderMask paints over this; white makes the gradient visible
+                            color: Colors.white,
+                          ),
+                        ),
+                      ),
+                      if (endOfDayTime != null)
+                        Text(
+                          _formatTime(endOfDayTime!),
+                          style: TextStyle(
+                            fontFamily: TileTextStyles.rubikFontName,
+                            fontSize: 12,
+                            color: colorScheme.onSurface.withOpacity(0.5),
+                          ),
+                        ),
+                    ],
+                  ),
+                  const SizedBox(width: 6),
+                  Icon(
+                    Icons.chevron_right,
+                    size: 16,
+                    color: _sunsetPurple.withOpacity(0.6),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-const bool isProduction = false;
+const bool isProduction = true;
 const bool isDebug = !isProduction;
 // const bool isDebug = true;
 const bool isStaging = true;
@@ -25,7 +25,7 @@ const Duration retryLoginDuration = Duration(seconds: 2);
 const int retryLoginCount = 150;
 String googleClientDefaultKey = 'GOOGLE_CLIENT_ID_DEFAULT';
 String googleClientIdKey =
-    Platform.isIOS ? 'GOOGLE_CLIENT_ID_IOS' : 'GOOGLE_CLIENT_ID_DEFAULT';
+    Platform.isIOS ? 'GOOGLE_CLIENT_ID_IOS' : 'GOOGLER_CLIENT_ID_DEFAULT';
 String googleClientSecretKey = 'GOOGLE_CLIENT_SECRET';
 String oneSignalAppIdKey =
     isProduction ? 'ONE_SIGNAL_APP_ID' : 'ONE_SIGNAL_APP_ID_DEV';

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1668,5 +1668,6 @@
             "notesViewerTitle": "Note",
             "notesTapToAdd": "Tap to add a note",
             "notesTapToEdit": "Tap to edit · long press to read",
-            "notesDone": "Done"
+            "notesDone": "Done",
+            "endOfDay": "End of Day"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -584,5 +584,6 @@
     "notesTapToAdd": "Toca para añadir una nota",
     "notesTapToEdit": "Toca para editar · mantén presionado para leer",
     "notesDone": "Listo",
-    "invalidContactFormat": "No es un correo electrónico o número de teléfono válido"
+    "invalidContactFormat": "No es un correo electrónico o número de teléfono válido",
+    "endOfDay": "Fin del día"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4558,6 +4558,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Done'**
   String get notesDone;
+
+  /// No description provided for @endOfDay.
+  ///
+  /// In en, this message translates to:
+  /// **'End of Day'**
+  String get endOfDay;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2536,4 +2536,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get notesDone => 'Done';
+
+  @override
+  String get endOfDay => 'End of Day';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2543,4 +2543,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get notesDone => 'Listo';
+
+  @override
+  String get endOfDay => 'Fin del día';
 }

--- a/test/end_of_day_helper_test.dart
+++ b/test/end_of_day_helper_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tiler_app/components/tilelist/dailyView/dailyTileList.dart';
+
+void main() {
+  group('endOfDayDateTimeFor', () {
+    test('combines day with TimeOfDay into a DateTime', () {
+      final day = DateTime(2024, 6, 10);
+      const timeOfDay = TimeOfDay(hour: 22, minute: 0);
+      final result = endOfDayDateTimeFor(day, timeOfDay);
+      expect(result, equals(DateTime(2024, 6, 10, 22, 0)));
+    });
+
+    test('preserves minutes', () {
+      final day = DateTime(2024, 3, 15);
+      const timeOfDay = TimeOfDay(hour: 21, minute: 30);
+      final result = endOfDayDateTimeFor(day, timeOfDay);
+      expect(result, equals(DateTime(2024, 3, 15, 21, 30)));
+    });
+
+    test('returns null when TimeOfDay is null', () {
+      final day = DateTime(2024, 6, 10);
+      final result = endOfDayDateTimeFor(day, null);
+      expect(result, isNull);
+    });
+
+    test('ignores time component of the day param — uses only date', () {
+      final dayWithTime = DateTime(2024, 6, 10, 14, 35, 22);
+      const timeOfDay = TimeOfDay(hour: 22, minute: 0);
+      final result = endOfDayDateTimeFor(dayWithTime, timeOfDay);
+      expect(result, equals(DateTime(2024, 6, 10, 22, 0)));
+    });
+  });
+}

--- a/test/enhanced_tile_batch_test.dart
+++ b/test/enhanced_tile_batch_test.dart
@@ -13,6 +13,7 @@ import 'package:tiler_app/components/tilelist/dailyView/enhancedWithinNowBatch.d
 import 'package:tiler_app/components/tilelist/extendedTilesBanner.dart';
 import 'package:tiler_app/components/tilelist/pendingRsvpBanner.dart';
 import 'package:tiler_app/components/tilelist/proactiveAlertBanner.dart';
+import 'package:tiler_app/components/tilelist/returnConnector.dart';
 import 'package:tiler_app/components/tilelist/travelConnector.dart';
 import 'package:tiler_app/components/tileUI/emptyDayTile.dart';
 import 'package:tiler_app/components/tileUI/sleepTile.dart';
@@ -64,7 +65,8 @@ void main() {
             addressDescription: 'hiking trail',
             start: DateTime(2026, 5, 15, 12, 15),
             end: DateTime(2026, 5, 15, 13, 45),
-            travelTimeBeforeMs: const Duration(minutes: 25).inMilliseconds.toDouble(),
+            travelTimeBeforeMs:
+                const Duration(minutes: 25).inMilliseconds.toDouble(),
             travelDetail: TravelDetail(
               before: TravelData(
                 travelMedium: 'driving',
@@ -123,12 +125,14 @@ void main() {
         expect(
           connectorY,
           greaterThan(conflictY),
-          reason: 'The travel connector must render after the conflicting block that occurs before the destination tile.',
+          reason:
+              'The travel connector must render after the conflicting block that occurs before the destination tile.',
         );
         expect(
           connectorY,
           lessThan(destinationY),
-          reason: 'The travel connector must render immediately before the destination tile it describes.',
+          reason:
+              'The travel connector must render immediately before the destination tile it describes.',
         );
       },
     );
@@ -180,10 +184,8 @@ void main() {
             travelDetail: TravelDetail(
               before: TravelData(
                 travelMedium: 'driving',
-                startLocation:
-                    _location('123 Office St', 37.33, -122.03),
-                endLocation:
-                    _location('456 Trail Rd', 37.44, -122.15),
+                startLocation: _location('123 Office St', 37.33, -122.03),
+                endLocation: _location('456 Trail Rd', 37.44, -122.15),
                 travelLegs: const [
                   TravelLeg(description: 'Head west on Highway 9'),
                 ],
@@ -197,8 +199,7 @@ void main() {
             child: MultiBlocProvider(
               providers: [
                 BlocProvider(
-                  create: (_) =>
-                      ScheduleBloc(getContextCallBack: () => null),
+                  create: (_) => ScheduleBloc(getContextCallBack: () => null),
                 ),
                 BlocProvider(
                   create: (_) =>
@@ -249,7 +250,8 @@ void main() {
       expect(find.byType(EmptyDayTile), findsOneWidget);
     });
 
-    testWidgets('renders viable tile names in the main tile list', (tester) async {
+    testWidgets('renders viable tile names in the main tile list',
+        (tester) async {
       final day = DateTime(2024, 6, 10);
       final tiles = [
         _buildTile(
@@ -265,27 +267,44 @@ void main() {
           end: DateTime(2024, 6, 10, 11, 30),
         ),
       ];
-      await _pumpETB(tester, tiles, dayIndex: day.difference(DateTime.utc(1970, 1, 1)).inDays);
+      await _pumpETB(tester, tiles,
+          dayIndex: day.difference(DateTime.utc(1970, 1, 1)).inDays);
       expect(find.text('Morning Standup'), findsOneWidget);
       expect(find.text('Code Review'), findsOneWidget);
     });
 
-    testWidgets('hides non-viable tile from the main tile list', (tester) async {
+    testWidgets('hides non-viable tile from the main tile list',
+        (tester) async {
       final day = DateTime(2024, 6, 10);
       final tiles = [
-        _buildTile(id: 'a', name: 'Visible Task', start: DateTime(2024, 6, 10, 9), end: DateTime(2024, 6, 10, 9, 30)),
-        _buildTile(id: 'b', name: 'Ghost Task', start: DateTime(2024, 6, 10, 10), end: DateTime(2024, 6, 10, 10, 30)),
+        _buildTile(
+            id: 'a',
+            name: 'Visible Task',
+            start: DateTime(2024, 6, 10, 9),
+            end: DateTime(2024, 6, 10, 9, 30)),
+        _buildTile(
+            id: 'b',
+            name: 'Ghost Task',
+            start: DateTime(2024, 6, 10, 10),
+            end: DateTime(2024, 6, 10, 10, 30)),
       ];
       tiles[1].isViable = false;
-      await _pumpETB(tester, tiles, dayIndex: day.difference(DateTime.utc(1970, 1, 1)).inDays);
+      await _pumpETB(tester, tiles,
+          dayIndex: day.difference(DateTime.utc(1970, 1, 1)).inDays);
       expect(find.text('Visible Task'), findsOneWidget);
       expect(find.text('Ghost Task'), findsNothing);
     });
 
-    testWidgets('routes needsAction RSVP tile to PendingRsvpBanner instead of main list', (tester) async {
+    testWidgets(
+        'routes needsAction RSVP tile to PendingRsvpBanner instead of main list',
+        (tester) async {
       final day = DateTime(2024, 6, 10);
       final tiles = [
-        _buildTile(id: 'a', name: 'Regular Meeting', start: DateTime(2024, 6, 10, 9), end: DateTime(2024, 6, 10, 9, 30)),
+        _buildTile(
+            id: 'a',
+            name: 'Regular Meeting',
+            start: DateTime(2024, 6, 10, 9),
+            end: DateTime(2024, 6, 10, 9, 30)),
         _buildRsvpTile(
           id: 'b',
           name: 'Pending Invite',
@@ -294,15 +313,22 @@ void main() {
           rsvp: RsvpStatus.needsAction,
         ),
       ];
-      await _pumpETB(tester, tiles, dayIndex: day.difference(DateTime.utc(1970, 1, 1)).inDays);
+      await _pumpETB(tester, tiles,
+          dayIndex: day.difference(DateTime.utc(1970, 1, 1)).inDays);
       expect(find.byType(PendingRsvpBanner), findsOneWidget);
     });
 
-    testWidgets('routes declined RSVP tile to RSVP banner and excludes it from conflict detection', (tester) async {
+    testWidgets(
+        'routes declined RSVP tile to RSVP banner and excludes it from conflict detection',
+        (tester) async {
       final day = DateTime(2024, 6, 10);
       // Two tiles at identical times — if both reached conflict detection they would form a conflict group.
       final tiles = [
-        _buildTile(id: 'a', name: 'Work Session', start: DateTime(2024, 6, 10, 9), end: DateTime(2024, 6, 10, 10)),
+        _buildTile(
+            id: 'a',
+            name: 'Work Session',
+            start: DateTime(2024, 6, 10, 9),
+            end: DateTime(2024, 6, 10, 10)),
         _buildRsvpTile(
           id: 'b',
           name: 'Declined Event',
@@ -311,28 +337,50 @@ void main() {
           rsvp: RsvpStatus.declined,
         ),
       ];
-      await _pumpETB(tester, tiles, dayIndex: day.difference(DateTime.utc(1970, 1, 1)).inDays);
+      await _pumpETB(tester, tiles,
+          dayIndex: day.difference(DateTime.utc(1970, 1, 1)).inDays);
       expect(find.byType(PendingRsvpBanner), findsOneWidget);
       expect(find.byType(ConflictSummaryBanner), findsNothing);
       expect(find.byType(CombinedAlertsBanner), findsNothing);
     });
 
-    testWidgets('shows ConflictSummaryBanner for a single overlapping tile pair', (tester) async {
+    testWidgets(
+        'shows ConflictSummaryBanner for a single overlapping tile pair',
+        (tester) async {
       final day = DateTime(2024, 6, 10);
       final tiles = [
-        _buildTile(id: 'c1', name: 'Task Alpha', start: DateTime(2024, 6, 10, 9), end: DateTime(2024, 6, 10, 10)),
-        _buildTile(id: 'c2', name: 'Task Beta', start: DateTime(2024, 6, 10, 9), end: DateTime(2024, 6, 10, 10, 30)),
+        _buildTile(
+            id: 'c1',
+            name: 'Task Alpha',
+            start: DateTime(2024, 6, 10, 9),
+            end: DateTime(2024, 6, 10, 10)),
+        _buildTile(
+            id: 'c2',
+            name: 'Task Beta',
+            start: DateTime(2024, 6, 10, 9),
+            end: DateTime(2024, 6, 10, 10, 30)),
       ];
-      await _pumpETB(tester, tiles, dayIndex: day.difference(DateTime.utc(1970, 1, 1)).inDays);
+      await _pumpETB(tester, tiles,
+          dayIndex: day.difference(DateTime.utc(1970, 1, 1)).inDays);
       expect(find.byType(ConflictSummaryBanner), findsOneWidget);
       expect(find.byType(CombinedAlertsBanner), findsNothing);
     });
 
-    testWidgets('shows CombinedAlertsBanner when conflicts and pending RSVP both exist', (tester) async {
+    testWidgets(
+        'shows CombinedAlertsBanner when conflicts and pending RSVP both exist',
+        (tester) async {
       final day = DateTime(2024, 6, 10);
       final tiles = [
-        _buildTile(id: 'c1', name: 'Task Alpha', start: DateTime(2024, 6, 10, 9), end: DateTime(2024, 6, 10, 10)),
-        _buildTile(id: 'c2', name: 'Task Beta', start: DateTime(2024, 6, 10, 9), end: DateTime(2024, 6, 10, 10, 30)),
+        _buildTile(
+            id: 'c1',
+            name: 'Task Alpha',
+            start: DateTime(2024, 6, 10, 9),
+            end: DateTime(2024, 6, 10, 10)),
+        _buildTile(
+            id: 'c2',
+            name: 'Task Beta',
+            start: DateTime(2024, 6, 10, 9),
+            end: DateTime(2024, 6, 10, 10, 30)),
         _buildRsvpTile(
           id: 'r1',
           name: 'Pending Invite',
@@ -341,22 +389,30 @@ void main() {
           rsvp: RsvpStatus.needsAction,
         ),
       ];
-      await _pumpETB(tester, tiles, dayIndex: day.difference(DateTime.utc(1970, 1, 1)).inDays);
+      await _pumpETB(tester, tiles,
+          dayIndex: day.difference(DateTime.utc(1970, 1, 1)).inDays);
       expect(find.byType(CombinedAlertsBanner), findsOneWidget);
       expect(find.byType(ConflictSummaryBanner), findsNothing);
     });
 
-    testWidgets('hides all TravelConnector widgets when showTravelConnectors is false', (tester) async {
+    testWidgets(
+        'hides all TravelConnector widgets when showTravelConnectors is false',
+        (tester) async {
       final day = DateTime(2024, 6, 10);
       final tiles = [
-        _buildTile(id: 'src', name: 'Office Meeting', start: DateTime(2024, 6, 10, 9), end: DateTime(2024, 6, 10, 10)),
+        _buildTile(
+            id: 'src',
+            name: 'Office Meeting',
+            start: DateTime(2024, 6, 10, 9),
+            end: DateTime(2024, 6, 10, 10)),
         _buildTile(
           id: 'dst',
           name: 'Client Visit',
           start: DateTime(2024, 6, 10, 11),
           end: DateTime(2024, 6, 10, 12),
           address: '123 Main St',
-          travelTimeBeforeMs: const Duration(minutes: 20).inMilliseconds.toDouble(),
+          travelTimeBeforeMs:
+              const Duration(minutes: 20).inMilliseconds.toDouble(),
           travelDetail: TravelDetail(
             before: TravelData(
               travelMedium: 'driving',
@@ -376,7 +432,9 @@ void main() {
       expect(find.byType(TravelConnector), findsNothing);
     });
 
-    testWidgets('shows ExtendedTilesBanner for a tile with duration of at least 16 hours', (tester) async {
+    testWidgets(
+        'shows ExtendedTilesBanner for a tile with duration of at least 16 hours',
+        (tester) async {
       final day = DateTime(2024, 6, 10);
       final tiles = [
         // 6:00 → 23:00 = 17 hours
@@ -387,11 +445,14 @@ void main() {
           end: DateTime(2024, 6, 10, 23),
         ),
       ];
-      await _pumpETB(tester, tiles, dayIndex: day.difference(DateTime.utc(1970, 1, 1)).inDays);
+      await _pumpETB(tester, tiles,
+          dayIndex: day.difference(DateTime.utc(1970, 1, 1)).inDays);
       expect(find.byType(ExtendedTilesBanner), findsOneWidget);
     });
 
-    testWidgets('does not show ProactiveAlertBanner for a non-today day even with travel time', (tester) async {
+    testWidgets(
+        'does not show ProactiveAlertBanner for a non-today day even with travel time',
+        (tester) async {
       final day = DateTime(2020, 1, 1);
       final tiles = [
         _buildTile(
@@ -399,7 +460,8 @@ void main() {
           name: 'Past Event',
           start: DateTime(2020, 1, 1, 9),
           end: DateTime(2020, 1, 1, 10),
-          travelTimeBeforeMs: const Duration(minutes: 15).inMilliseconds.toDouble(),
+          travelTimeBeforeMs:
+              const Duration(minutes: 15).inMilliseconds.toDouble(),
         ),
       ];
       await _pumpETB(
@@ -418,7 +480,8 @@ void main() {
       expect(find.byType(EmptyDayTile), findsOneWidget);
     });
 
-    testWidgets('always renders TodaySummaryRow regardless of tile count', (tester) async {
+    testWidgets('always renders TodaySummaryRow regardless of tile count',
+        (tester) async {
       final today = DateTime.now();
       final tiles = [
         _buildTile(
@@ -432,7 +495,8 @@ void main() {
       expect(find.byType(TodaySummaryRow), findsOneWidget);
     });
 
-    testWidgets('wraps each main-list tile in a TileRowWithHourMarker', (tester) async {
+    testWidgets('wraps each main-list tile in a TileRowWithHourMarker',
+        (tester) async {
       final today = DateTime.now();
       final tiles = [
         _buildTile(
@@ -452,7 +516,8 @@ void main() {
       expect(find.byType(TileRowWithHourMarker), findsWidgets);
     });
 
-    testWidgets('renders SleepTileWidget when sleepTimeline is provided', (tester) async {
+    testWidgets('renders SleepTileWidget when sleepTimeline is provided',
+        (tester) async {
       final today = DateTime.now();
       final sleepTimeline = _buildTimeline(
         DateTime(today.year, today.month, today.day, 22),
@@ -462,7 +527,8 @@ void main() {
       expect(find.byType(SleepTileWidget), findsOneWidget);
     });
 
-    testWidgets('routes needsAction RSVP tile to PendingRsvpBanner', (tester) async {
+    testWidgets('routes needsAction RSVP tile to PendingRsvpBanner',
+        (tester) async {
       final today = DateTime.now();
       final tiles = [
         _buildTile(
@@ -483,7 +549,8 @@ void main() {
       expect(find.byType(PendingRsvpBanner), findsOneWidget);
     });
 
-    testWidgets('excludes declined tile from conflict detection', (tester) async {
+    testWidgets('excludes declined tile from conflict detection',
+        (tester) async {
       final today = DateTime.now();
       // Two tiles at the exact same time. The declined one is filtered out before conflict
       // detection runs, so only one tile remains — no conflict group is formed.
@@ -506,7 +573,9 @@ void main() {
       expect(find.text('2 conflicts'), findsNothing);
     });
 
-    testWidgets('shows ProactiveAlertBanner alone for a future tile with travel time', (tester) async {
+    testWidgets(
+        'shows ProactiveAlertBanner alone for a future tile with travel time',
+        (tester) async {
       final futureStart = DateTime.now().add(const Duration(hours: 2));
       final futureEnd = futureStart.add(const Duration(hours: 1));
       final tiles = [
@@ -515,7 +584,8 @@ void main() {
           name: 'Client Drive',
           start: futureStart,
           end: futureEnd,
-          travelTimeBeforeMs: const Duration(minutes: 30).inMilliseconds.toDouble(),
+          travelTimeBeforeMs:
+              const Duration(minutes: 30).inMilliseconds.toDouble(),
         ),
       ];
       await _pumpEWNB(tester, tiles);
@@ -523,7 +593,9 @@ void main() {
       expect(find.byType(CombinedAlertsBanner), findsNothing);
     });
 
-    testWidgets('shows CombinedAlertsBanner when travel alert and pending RSVP both exist', (tester) async {
+    testWidgets(
+        'shows CombinedAlertsBanner when travel alert and pending RSVP both exist',
+        (tester) async {
       final today = DateTime.now();
       final futureStart = today.add(const Duration(hours: 2));
       final futureEnd = futureStart.add(const Duration(hours: 1));
@@ -533,7 +605,8 @@ void main() {
           name: 'Client Drive',
           start: futureStart,
           end: futureEnd,
-          travelTimeBeforeMs: const Duration(minutes: 30).inMilliseconds.toDouble(),
+          travelTimeBeforeMs:
+              const Duration(minutes: 30).inMilliseconds.toDouble(),
         ),
         _buildRsvpTile(
           id: 'rsvp',
@@ -546,6 +619,144 @@ void main() {
       await _pumpEWNB(tester, tiles);
       expect(find.byType(CombinedAlertsBanner), findsOneWidget);
       expect(find.byType(ProactiveAlertBanner), findsNothing);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // endOfDayTime threading — EnhancedWithinNowBatch
+  // ---------------------------------------------------------------------------
+
+  group('EnhancedWithinNowBatch — endOfDayTime is threaded to ReturnConnector',
+      () {
+    testWidgets('renders ReturnConnector when last tile has travelTimeAfter',
+        (tester) async {
+      final today = DateTime.now();
+      final tiles = [
+        _buildTile(
+          id: 'last',
+          name: 'Last Task',
+          start: DateTime(today.year, today.month, today.day, 17),
+          end: DateTime(today.year, today.month, today.day, 18),
+          travelTimeAfterMs:
+              const Duration(minutes: 20).inMilliseconds.toDouble(),
+        ),
+      ];
+      await _pumpEWNB(tester, tiles);
+      expect(find.byType(ReturnConnector), findsOneWidget);
+    });
+
+    testWidgets('ReturnConnector receives endOfDayTime when provided',
+        (tester) async {
+      final today = DateTime.now();
+      final endOfDay = DateTime(today.year, today.month, today.day, 22, 0);
+      final tiles = [
+        _buildTile(
+          id: 'last',
+          name: 'Last Task',
+          start: DateTime(today.year, today.month, today.day, 17),
+          end: DateTime(today.year, today.month, today.day, 18),
+          travelTimeAfterMs:
+              const Duration(minutes: 20).inMilliseconds.toDouble(),
+        ),
+      ];
+      await _pumpEWNB(tester, tiles, endOfDayTime: endOfDay);
+      final connector =
+          tester.widget<ReturnConnector>(find.byType(ReturnConnector));
+      expect(connector.endOfDayTime, equals(endOfDay));
+    });
+
+    testWidgets('ReturnConnector.endOfDayTime is null when not provided',
+        (tester) async {
+      final today = DateTime.now();
+      final tiles = [
+        _buildTile(
+          id: 'last',
+          name: 'Last Task',
+          start: DateTime(today.year, today.month, today.day, 17),
+          end: DateTime(today.year, today.month, today.day, 18),
+          travelTimeAfterMs:
+              const Duration(minutes: 20).inMilliseconds.toDouble(),
+        ),
+      ];
+      await _pumpEWNB(tester, tiles);
+      final connector =
+          tester.widget<ReturnConnector>(find.byType(ReturnConnector));
+      expect(connector.endOfDayTime, isNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // endOfDayTime threading — EnhancedTileBatch
+  // ---------------------------------------------------------------------------
+
+  group('EnhancedTileBatch — endOfDayTime is threaded to ReturnConnector', () {
+    testWidgets('renders ReturnConnector when last tile has travelTimeAfter',
+        (tester) async {
+      final day = DateTime(2024, 6, 10);
+      final tiles = [
+        _buildTile(
+          id: 'last',
+          name: 'Last Meeting',
+          start: DateTime(2024, 6, 10, 15),
+          end: DateTime(2024, 6, 10, 16),
+          travelTimeAfterMs:
+              const Duration(minutes: 15).inMilliseconds.toDouble(),
+        ),
+      ];
+      await _pumpETB(
+        tester,
+        tiles,
+        dayIndex: day.difference(DateTime.utc(1970, 1, 1)).inDays,
+      );
+      expect(find.byType(ReturnConnector), findsOneWidget);
+    });
+
+    testWidgets('ReturnConnector receives endOfDayTime when provided',
+        (tester) async {
+      final day = DateTime(2024, 6, 10);
+      final endOfDay = DateTime(2024, 6, 10, 22, 0);
+      final tiles = [
+        _buildTile(
+          id: 'last',
+          name: 'Last Meeting',
+          start: DateTime(2024, 6, 10, 15),
+          end: DateTime(2024, 6, 10, 16),
+          travelTimeAfterMs:
+              const Duration(minutes: 15).inMilliseconds.toDouble(),
+        ),
+      ];
+      await _pumpETB(
+        tester,
+        tiles,
+        dayIndex: day.difference(DateTime.utc(1970, 1, 1)).inDays,
+        endOfDayTime: endOfDay,
+      );
+      final connector =
+          tester.widget<ReturnConnector>(find.byType(ReturnConnector));
+      expect(connector.endOfDayTime, equals(endOfDay));
+    });
+
+    testWidgets('ReturnConnector.endOfDayTime is null when not provided',
+        (tester) async {
+      final day = DateTime(2024, 6, 10);
+      final tiles = [
+        _buildTile(
+          id: 'last',
+          name: 'Last Meeting',
+          start: DateTime(2024, 6, 10, 15),
+          end: DateTime(2024, 6, 10, 16),
+          travelTimeAfterMs:
+              const Duration(minutes: 15).inMilliseconds.toDouble(),
+        ),
+      ];
+      await _pumpETB(
+        tester,
+        tiles,
+        dayIndex: day.difference(DateTime.utc(1970, 1, 1)).inDays,
+      );
+      final connector =
+          tester.widget<ReturnConnector>(find.byType(ReturnConnector));
+      expect(connector.endOfDayTime, isNull);
     });
   });
 }
@@ -572,6 +783,7 @@ SubCalendarEvent _buildTile({
   String? address,
   String? addressDescription,
   double? travelTimeBeforeMs,
+  double? travelTimeAfterMs,
   TravelDetail? travelDetail,
 }) {
   final tile = SubCalendarEvent(
@@ -583,6 +795,7 @@ SubCalendarEvent _buildTile({
     addressDescription: addressDescription,
   );
   tile.travelTimeBefore = travelTimeBeforeMs;
+  tile.travelTimeAfter = travelTimeAfterMs;
   tile.travelDetail = travelDetail;
   return tile;
 }
@@ -628,6 +841,7 @@ Future<void> _pumpETB(
   bool showProactiveAlerts = false,
   bool showTravelConnectors = true,
   bool showConflictAlerts = true,
+  DateTime? endOfDayTime,
 }) async {
   tester.view.physicalSize = const Size(1080, 2400);
   tester.view.devicePixelRatio = 1.0;
@@ -635,14 +849,17 @@ Future<void> _pumpETB(
     tester.view.resetPhysicalSize();
     tester.view.resetDevicePixelRatio();
   });
-  final idx =
-      dayIndex ?? DateTime(2020, 1, 1).difference(DateTime.utc(1970, 1, 1)).inDays;
+  final idx = dayIndex ??
+      DateTime(2020, 1, 1).difference(DateTime.utc(1970, 1, 1)).inDays;
   await tester.pumpWidget(
     _buildTestApp(
       child: MultiBlocProvider(
         providers: [
-          BlocProvider(create: (_) => ScheduleBloc(getContextCallBack: () => null)),
-          BlocProvider(create: (_) => ScheduleSummaryBloc(getContextCallBack: () => null)),
+          BlocProvider(
+              create: (_) => ScheduleBloc(getContextCallBack: () => null)),
+          BlocProvider(
+              create: (_) =>
+                  ScheduleSummaryBloc(getContextCallBack: () => null)),
         ],
         child: Scaffold(
           body: SingleChildScrollView(
@@ -654,6 +871,7 @@ Future<void> _pumpETB(
               showEnhancedCards: true,
               showConflictAlerts: showConflictAlerts,
               showTravelConnectors: showTravelConnectors,
+              endOfDayTime: endOfDayTime,
             ),
           ),
         ),
@@ -675,6 +893,7 @@ Future<void> _pumpEWNB(
   WidgetTester tester,
   List<SubCalendarEvent> tiles, {
   Timeline? sleepTimeline,
+  DateTime? endOfDayTime,
 }) async {
   tester.view.physicalSize = const Size(1080, 2400);
   tester.view.devicePixelRatio = 1.0;
@@ -686,13 +905,17 @@ Future<void> _pumpEWNB(
     _buildTestApp(
       child: MultiBlocProvider(
         providers: [
-          BlocProvider(create: (_) => ScheduleBloc(getContextCallBack: () => null)),
-          BlocProvider(create: (_) => ScheduleSummaryBloc(getContextCallBack: () => null)),
+          BlocProvider(
+              create: (_) => ScheduleBloc(getContextCallBack: () => null)),
+          BlocProvider(
+              create: (_) =>
+                  ScheduleSummaryBloc(getContextCallBack: () => null)),
         ],
         child: Scaffold(
           body: EnhancedWithinNowBatch(
             tiles: tiles,
             sleepTimeline: sleepTimeline,
+            endOfDayTime: endOfDayTime,
           ),
         ),
       ),

--- a/test/return_connector_test.dart
+++ b/test/return_connector_test.dart
@@ -1,0 +1,324 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:tiler_app/components/tilelist/returnConnector.dart';
+import 'package:tiler_app/data/location.dart';
+import 'package:tiler_app/data/subCalendarEvent.dart';
+import 'package:tiler_app/data/travelDetail.dart';
+import 'package:tiler_app/l10n/app_localizations.dart';
+import 'package:tiler_app/theme/theme_data.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // ---------------------------------------------------------------------------
+  // Helper builders
+  // ---------------------------------------------------------------------------
+
+  SubCalendarEvent _buildLastTile({
+    required DateTime end,
+    double? travelTimeAfter,
+    TravelDetail? travelDetail,
+  }) {
+    final tile = SubCalendarEvent(
+      id: 'last-tile',
+      name: 'Last Event',
+      start: end.subtract(const Duration(hours: 1)).millisecondsSinceEpoch,
+      end: end.millisecondsSinceEpoch,
+    );
+    tile.travelTimeAfter = travelTimeAfter;
+    tile.travelDetail = travelDetail;
+    return tile;
+  }
+
+  Location _homeLocation() {
+    final loc =
+        Location.fromLatitudeAndLongitude(latitude: 37.7, longitude: -122.4);
+    loc.description = Location.homeLocationNickName; // 'home'
+    loc.address = '123 Home St';
+    return loc;
+  }
+
+  Location _otherLocation(String address) {
+    final loc =
+        Location.fromLatitudeAndLongitude(latitude: 37.8, longitude: -122.5);
+    loc.address = address;
+    loc.description = address;
+    return loc;
+  }
+
+  Widget _wrap(Widget child) {
+    return MaterialApp(
+      theme: TileThemeData.lightTheme,
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: child),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Group 1: End-of-day section always renders
+  // ---------------------------------------------------------------------------
+
+  group('ReturnConnector — end-of-day section always rendered', () {
+    testWidgets('wb_twilight icon visible with no travel data', (tester) async {
+      final tile = _buildLastTile(end: DateTime(2026, 6, 28, 19));
+      await tester.pumpWidget(_wrap(ReturnConnector(lastTile: tile)));
+      await tester.pump();
+      expect(find.byIcon(Icons.wb_twilight), findsOneWidget);
+    });
+
+    testWidgets('"End of Day" text always shown', (tester) async {
+      final tile = _buildLastTile(end: DateTime(2026, 6, 28, 19));
+      await tester.pumpWidget(_wrap(ReturnConnector(lastTile: tile)));
+      await tester.pump();
+      expect(find.text('End of Day'), findsOneWidget);
+    });
+
+    testWidgets('wb_twilight icon present even when travel data is present',
+        (tester) async {
+      final tile = _buildLastTile(
+        end: DateTime(2026, 6, 28, 19),
+        travelTimeAfter: const Duration(minutes: 20).inMilliseconds.toDouble(),
+        travelDetail: TravelDetail(
+          after: TravelData(
+            endLocation: _homeLocation(),
+            duration: const Duration(minutes: 20).inMilliseconds.toDouble(),
+          ),
+        ),
+      );
+      await tester.pumpWidget(_wrap(ReturnConnector(lastTile: tile)));
+      await tester.pump();
+      expect(find.byIcon(Icons.wb_twilight), findsOneWidget);
+      expect(find.text('End of Day'), findsOneWidget);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Group 2: End-of-day time
+  // ---------------------------------------------------------------------------
+
+  group('ReturnConnector — end-of-day time display', () {
+    testWidgets('shows time text when endOfDayTime is provided',
+        (tester) async {
+      final tile = _buildLastTile(end: DateTime(2026, 6, 28, 19));
+      final eod = DateTime(2026, 6, 28, 22, 0); // 10:00 PM
+      await tester.pumpWidget(
+          _wrap(ReturnConnector(lastTile: tile, endOfDayTime: eod)));
+      await tester.pump();
+      expect(find.textContaining('PM'), findsAtLeastNWidgets(1));
+    });
+
+    testWidgets('does not show time text when endOfDayTime is null',
+        (tester) async {
+      final tile = _buildLastTile(end: DateTime(2026, 6, 28, 19));
+      await tester.pumpWidget(_wrap(ReturnConnector(lastTile: tile)));
+      await tester.pump();
+      expect(find.textContaining('PM'), findsNothing);
+      expect(find.textContaining('AM'), findsNothing);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Group 3: No travel data — travel section hidden
+  // ---------------------------------------------------------------------------
+
+  group('ReturnConnector — no travel data hides travel-specific elements', () {
+    testWidgets('no home icon when no travel data', (tester) async {
+      final tile = _buildLastTile(end: DateTime(2026, 6, 28, 19));
+      await tester.pumpWidget(_wrap(ReturnConnector(lastTile: tile)));
+      await tester.pump();
+      expect(find.byIcon(Icons.home), findsNothing);
+    });
+
+    testWidgets('no navigation icon when no travel data', (tester) async {
+      final tile = _buildLastTile(end: DateTime(2026, 6, 28, 19));
+      await tester.pumpWidget(_wrap(ReturnConnector(lastTile: tile)));
+      await tester.pump();
+      expect(find.byIcon(Icons.navigation_outlined), findsNothing);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Group 4: Home destination
+  // ---------------------------------------------------------------------------
+
+  group('ReturnConnector — home destination travel section', () {
+    testWidgets('shows home icon in travel section', (tester) async {
+      final tile = _buildLastTile(
+        end: DateTime(2026, 6, 28, 19),
+        travelTimeAfter: const Duration(minutes: 20).inMilliseconds.toDouble(),
+        travelDetail: TravelDetail(
+          after: TravelData(
+            travelMedium: 'driving',
+            endLocation: _homeLocation(),
+            duration: const Duration(minutes: 20).inMilliseconds.toDouble(),
+          ),
+        ),
+      );
+      await tester.pumpWidget(_wrap(ReturnConnector(lastTile: tile)));
+      await tester.pump();
+      expect(find.byIcon(Icons.home), findsOneWidget);
+    });
+
+    testWidgets('does not show navigation icon for home (no outbound nav)',
+        (tester) async {
+      final tile = _buildLastTile(
+        end: DateTime(2026, 6, 28, 19),
+        travelDetail: TravelDetail(
+          after: TravelData(endLocation: _homeLocation()),
+        ),
+      );
+      await tester.pumpWidget(_wrap(ReturnConnector(lastTile: tile)));
+      await tester.pump();
+      expect(find.byIcon(Icons.navigation_outlined), findsNothing);
+    });
+
+    testWidgets('shows duration text for home with non-zero duration',
+        (tester) async {
+      final tile = _buildLastTile(
+        end: DateTime(2026, 6, 28, 19),
+        travelDetail: TravelDetail(
+          after: TravelData(
+            endLocation: _homeLocation(),
+            duration: const Duration(minutes: 25).inMilliseconds.toDouble(),
+          ),
+        ),
+      );
+      await tester.pumpWidget(_wrap(ReturnConnector(lastTile: tile)));
+      await tester.pump();
+      expect(find.textContaining('25'), findsOneWidget);
+    });
+
+    testWidgets('shows "Home" destination label', (tester) async {
+      final tile = _buildLastTile(
+        end: DateTime(2026, 6, 28, 19),
+        travelDetail: TravelDetail(
+          after: TravelData(endLocation: _homeLocation()),
+        ),
+      );
+      await tester.pumpWidget(_wrap(ReturnConnector(lastTile: tile)));
+      await tester.pump();
+      expect(find.text('Home'), findsOneWidget);
+    });
+
+    testWidgets('end-of-day time shown in end-of-day section below travel',
+        (tester) async {
+      final tile = _buildLastTile(
+        end: DateTime(2026, 6, 28, 19),
+        travelDetail: TravelDetail(
+          after: TravelData(
+            travelMedium: 'driving',
+            endLocation: _homeLocation(),
+            duration: const Duration(minutes: 20).inMilliseconds.toDouble(),
+          ),
+        ),
+      );
+      final eod = DateTime(2026, 6, 28, 22, 0);
+      await tester.pumpWidget(
+          _wrap(ReturnConnector(lastTile: tile, endOfDayTime: eod)));
+      await tester.pump();
+      expect(find.textContaining('10'), findsOneWidget);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Group 5: Non-home location travel section
+  // ---------------------------------------------------------------------------
+
+  group('ReturnConnector — non-home location travel section', () {
+    testWidgets('shows navigation icon for non-home location', (tester) async {
+      final tile = _buildLastTile(
+        end: DateTime(2026, 6, 28, 19),
+        travelDetail: TravelDetail(
+          after: TravelData(
+            travelMedium: 'driving',
+            endLocation: _otherLocation('456 Office Blvd'),
+            duration: const Duration(minutes: 10).inMilliseconds.toDouble(),
+          ),
+        ),
+      );
+      await tester.pumpWidget(_wrap(ReturnConnector(lastTile: tile)));
+      await tester.pump();
+      expect(find.byIcon(Icons.navigation_outlined), findsOneWidget);
+    });
+
+    testWidgets('shows destination description text', (tester) async {
+      final tile = _buildLastTile(
+        end: DateTime(2026, 6, 28, 19),
+        travelDetail: TravelDetail(
+          after: TravelData(
+            travelMedium: 'driving',
+            endLocation: _otherLocation('456 Office Blvd'),
+            duration: const Duration(minutes: 10).inMilliseconds.toDouble(),
+          ),
+        ),
+      );
+      await tester.pumpWidget(_wrap(ReturnConnector(lastTile: tile)));
+      await tester.pump();
+      expect(find.textContaining('456 Office Blvd'), findsOneWidget);
+    });
+
+    testWidgets('wraps travel section in a GestureDetector', (tester) async {
+      final tile = _buildLastTile(
+        end: DateTime(2026, 6, 28, 19),
+        travelDetail: TravelDetail(
+          after: TravelData(
+            travelMedium: 'driving',
+            endLocation: _otherLocation('456 Office Blvd'),
+          ),
+        ),
+      );
+      await tester.pumpWidget(_wrap(ReturnConnector(lastTile: tile)));
+      await tester.pump();
+      expect(find.byType(GestureDetector), findsAtLeastNWidgets(1));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Group 6: Duration-only (no location)
+  // ---------------------------------------------------------------------------
+
+  group('ReturnConnector — duration-only travel section', () {
+    testWidgets('shows duration text when travelTimeAfter set, no travelDetail',
+        (tester) async {
+      final tile = _buildLastTile(
+        end: DateTime(2026, 6, 28, 19),
+        travelTimeAfter: const Duration(minutes: 15).inMilliseconds.toDouble(),
+      );
+      await tester.pumpWidget(_wrap(ReturnConnector(lastTile: tile)));
+      await tester.pump();
+      expect(find.textContaining('15'), findsOneWidget);
+    });
+
+    testWidgets('no navigation icon without valid location', (tester) async {
+      final tile = _buildLastTile(
+        end: DateTime(2026, 6, 28, 19),
+        travelTimeAfter: const Duration(minutes: 15).inMilliseconds.toDouble(),
+      );
+      await tester.pumpWidget(_wrap(ReturnConnector(lastTile: tile)));
+      await tester.pump();
+      expect(find.byIcon(Icons.navigation_outlined), findsNothing);
+    });
+
+    testWidgets('zero duration renders without crash and shows end-of-day',
+        (tester) async {
+      final tile = _buildLastTile(
+        end: DateTime(2026, 6, 28, 19),
+        travelTimeAfter: 0,
+        travelDetail: TravelDetail(
+          after: TravelData(endLocation: _homeLocation(), duration: 0),
+        ),
+      );
+      await tester.pumpWidget(_wrap(ReturnConnector(lastTile: tile)));
+      await tester.pump();
+      expect(find.byIcon(Icons.wb_twilight), findsOneWidget);
+      expect(find.text('End of Day'), findsOneWidget);
+    });
+  });
+}

--- a/test/tile_connector_layout_test.dart
+++ b/test/tile_connector_layout_test.dart
@@ -1,0 +1,311 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tiler_app/components/tilelist/dailyView/tileConnectorLayout.dart';
+import 'package:tiler_app/components/tilelist/returnConnector.dart';
+import 'package:tiler_app/data/location.dart';
+import 'package:tiler_app/data/subCalendarEvent.dart';
+import 'package:tiler_app/data/travelDetail.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+SubCalendarEvent _tile({
+  required String id,
+  required DateTime start,
+  required DateTime end,
+  double? travelTimeAfter,
+  TravelDetail? travelDetail,
+}) {
+  final t = SubCalendarEvent(
+    id: id,
+    name: id,
+    start: start.millisecondsSinceEpoch,
+    end: end.millisecondsSinceEpoch,
+  );
+  t.travelTimeAfter = travelTimeAfter;
+  t.travelDetail = travelDetail;
+  return t;
+}
+
+Location _homeLocation() {
+  final loc =
+      Location.fromLatitudeAndLongitude(latitude: 37.7, longitude: -122.4);
+  loc.description = Location.homeLocationNickName;
+  loc.address = '1 Home Lane';
+  return loc;
+}
+
+/// Calls [buildTileListWithConnectors] with minimal no-op callbacks.
+/// [wrapConnector] is the identity by default so connector widgets appear
+/// unmodified in the result list, making type-checks straightforward.
+TileConnectorLayoutResult _build(
+  List<SubCalendarEvent> tiles, {
+  DateTime? endOfDayTime,
+  bool showTravelConnectors = true,
+}) {
+  return buildTileListWithConnectors(
+    orderedTiles: tiles,
+    showTravelConnectors: showTravelConnectors,
+    showConflictAlerts: false,
+    excludeDeclinedFromConflicts: false,
+    now: DateTime(2026, 6, 28, 12),
+    endOfDayTime: endOfDayTime,
+    buildTile: (tile,
+            {required hour, required showHourMarker, required isCurrentHour}) =>
+        SizedBox(key: ValueKey(tile.id)),
+    buildConflictGroup: (group,
+            {required hour, required showHourMarker, required isCurrentHour}) =>
+        const SizedBox(),
+    wrapConnector: (connector) => connector,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  // -------------------------------------------------------------------------
+  // Group 1: Emission conditions
+  // -------------------------------------------------------------------------
+
+  group('buildTileListWithConnectors — post-loop ReturnConnector emission', () {
+    test('emits ReturnConnector when travelDetail.after is non-null', () {
+      final tiles = [
+        _tile(
+          id: 'last',
+          start: DateTime(2026, 6, 28, 18),
+          end: DateTime(2026, 6, 28, 19),
+          travelDetail: TravelDetail(
+            after: TravelData(
+              travelMedium: 'driving',
+              endLocation: _homeLocation(),
+              duration: const Duration(minutes: 20).inMilliseconds.toDouble(),
+            ),
+          ),
+        ),
+      ];
+
+      final result = _build(tiles);
+
+      expect(result.widgets.last, isA<ReturnConnector>());
+    });
+
+    test('emits ReturnConnector when travelTimeAfter is non-zero', () {
+      final tiles = [
+        _tile(
+          id: 'last',
+          start: DateTime(2026, 6, 28, 18),
+          end: DateTime(2026, 6, 28, 19),
+          travelTimeAfter:
+              const Duration(minutes: 15).inMilliseconds.toDouble(),
+        ),
+      ];
+
+      final result = _build(tiles);
+
+      expect(result.widgets.last, isA<ReturnConnector>());
+    });
+
+    test(
+        'emits ReturnConnector when travelTimeAfter is zero (data present, duration zero)',
+        () {
+      final tiles = [
+        _tile(
+          id: 'last',
+          start: DateTime(2026, 6, 28, 18),
+          end: DateTime(2026, 6, 28, 19),
+          travelTimeAfter: 0,
+          travelDetail: TravelDetail(
+            after: TravelData(
+              endLocation: _homeLocation(),
+              duration: 0,
+            ),
+          ),
+        ),
+      ];
+
+      final result = _build(tiles);
+
+      expect(result.widgets.last, isA<ReturnConnector>());
+    });
+
+    test('emits ReturnConnector even when no after-travel data is present', () {
+      final tiles = [
+        _tile(
+          id: 'last',
+          start: DateTime(2026, 6, 28, 18),
+          end: DateTime(2026, 6, 28, 19),
+          // no travelTimeAfter, no travelDetail
+        ),
+      ];
+
+      final result = _build(tiles);
+
+      expect(result.widgets.last, isA<ReturnConnector>());
+    });
+
+    test('does NOT emit ReturnConnector when tile list is empty', () {
+      final result = _build([]);
+
+      expect(result.widgets.whereType<ReturnConnector>(), isEmpty);
+    });
+
+    test('does NOT emit ReturnConnector when showTravelConnectors is false',
+        () {
+      final tiles = [
+        _tile(
+          id: 'last',
+          start: DateTime(2026, 6, 28, 18),
+          end: DateTime(2026, 6, 28, 19),
+          travelTimeAfter:
+              const Duration(minutes: 20).inMilliseconds.toDouble(),
+          travelDetail: TravelDetail(
+            after: TravelData(endLocation: _homeLocation()),
+          ),
+        ),
+      ];
+
+      final result = _build(tiles, showTravelConnectors: false);
+
+      expect(result.widgets.whereType<ReturnConnector>(), isEmpty);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Group 2: Ordering
+  // -------------------------------------------------------------------------
+
+  group('buildTileListWithConnectors — ReturnConnector position', () {
+    test('ReturnConnector is appended after the last tile widget', () {
+      final tiles = [
+        _tile(
+          id: 'first',
+          start: DateTime(2026, 6, 28, 9),
+          end: DateTime(2026, 6, 28, 10),
+        ),
+        _tile(
+          id: 'last',
+          start: DateTime(2026, 6, 28, 11),
+          end: DateTime(2026, 6, 28, 12),
+          travelTimeAfter:
+              const Duration(minutes: 20).inMilliseconds.toDouble(),
+          travelDetail: TravelDetail(
+            after: TravelData(endLocation: _homeLocation()),
+          ),
+        ),
+      ];
+
+      final result = _build(tiles);
+
+      // Last widget must be the ReturnConnector
+      expect(result.widgets.last, isA<ReturnConnector>());
+
+      // The second-to-last widget must be the last tile (SizedBox keyed 'last')
+      final secondToLast = result.widgets[result.widgets.length - 2];
+      expect(secondToLast, isA<SizedBox>());
+      expect((secondToLast as SizedBox).key, isA<ValueKey>());
+      expect(((secondToLast).key as ValueKey).value, equals('last'));
+    });
+
+    test(
+        'ReturnConnector is the only extra widget added (widget count = tiles + 1)',
+        () {
+      // Neither tile has travel data — the only extra widget is the ReturnConnector
+      // emitted for the last tile.
+      final tiles = [
+        _tile(
+          id: 'a',
+          start: DateTime(2026, 6, 28, 9),
+          end: DateTime(2026, 6, 28, 10),
+        ),
+        _tile(
+          id: 'b',
+          start: DateTime(2026, 6, 28, 11),
+          end: DateTime(2026, 6, 28, 12),
+        ),
+      ];
+
+      final result = _build(tiles);
+
+      // 2 tile widgets + 1 ReturnConnector = 3
+      expect(result.widgets.length, equals(3));
+      expect(result.widgets.whereType<ReturnConnector>().length, equals(1));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Group 3: endOfDayTime threading
+  // -------------------------------------------------------------------------
+
+  group(
+      'buildTileListWithConnectors — endOfDayTime is passed to ReturnConnector',
+      () {
+    test('ReturnConnector receives the provided endOfDayTime', () {
+      final endOfDay = DateTime(2026, 6, 28, 22, 0);
+      final tiles = [
+        _tile(
+          id: 'last',
+          start: DateTime(2026, 6, 28, 18),
+          end: DateTime(2026, 6, 28, 19),
+          travelTimeAfter:
+              const Duration(minutes: 20).inMilliseconds.toDouble(),
+          travelDetail: TravelDetail(
+            after: TravelData(endLocation: _homeLocation()),
+          ),
+        ),
+      ];
+
+      final result = _build(tiles, endOfDayTime: endOfDay);
+
+      final connector = result.widgets.last as ReturnConnector;
+      expect(connector.endOfDayTime, equals(endOfDay));
+    });
+
+    test('ReturnConnector receives null endOfDayTime when none is provided',
+        () {
+      final tiles = [
+        _tile(
+          id: 'last',
+          start: DateTime(2026, 6, 28, 18),
+          end: DateTime(2026, 6, 28, 19),
+          travelTimeAfter:
+              const Duration(minutes: 20).inMilliseconds.toDouble(),
+        ),
+      ];
+
+      final result = _build(tiles);
+
+      final connector = result.widgets.last as ReturnConnector;
+      expect(connector.endOfDayTime, isNull);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Group 4: lastTile reference on ReturnConnector
+  // -------------------------------------------------------------------------
+
+  group(
+      'buildTileListWithConnectors — ReturnConnector holds the correct lastTile',
+      () {
+    test('ReturnConnector.lastTile is the last tile in the ordered list', () {
+      final first = _tile(
+        id: 'first',
+        start: DateTime(2026, 6, 28, 9),
+        end: DateTime(2026, 6, 28, 10),
+      );
+      final last = _tile(
+        id: 'last',
+        start: DateTime(2026, 6, 28, 11),
+        end: DateTime(2026, 6, 28, 12),
+        travelTimeAfter: const Duration(minutes: 15).inMilliseconds.toDouble(),
+      );
+
+      final result = _build([first, last]);
+
+      final connector = result.widgets.last as ReturnConnector;
+      expect(connector.lastTile.id, equals('last'));
+    });
+  });
+}


### PR DESCRIPTION
This pull request introduces support for displaying and updating the user's configured "end-of-day" time in daily tile views. The changes ensure that the end-of-day time is consistently passed to and used within tile batches, and that the UI always displays a return connector after the last tile to visually indicate the end of the day. It also adds the ability to refresh the end-of-day setting from user preferences.

**End-of-day time support and propagation:**
- Added logic in `dailyTileList.dart` to fetch the user's end-of-day time from settings and propagate it to all tile batch widgets, including support for updating this value if changed. (`[[1]](diffhunk://#diff-4c609bc4e15fa72e467572c9ee1e62ef3158c229219c6e99dbd1f37b0382c317R18-R32)`, `[[2]](diffhunk://#diff-4c609bc4e15fa72e467572c9ee1e62ef3158c229219c6e99dbd1f37b0382c317R64-R66)`, `[[3]](diffhunk://#diff-4c609bc4e15fa72e467572c9ee1e62ef3158c229219c6e99dbd1f37b0382c317R75-R98)`)
- Updated constructors and widget trees for `EnhancedTileBatch` and `EnhancedWithinNowBatch` to accept and pass `endOfDayTime` and `onEndOfDayUpdated` callbacks. (`[[1]](diffhunk://#diff-c7264eb171709801bea5f00d550d1145de09a9e45ba709473fe822834541b9e6R42-R43)`, `[[2]](diffhunk://#diff-c7264eb171709801bea5f00d550d1145de09a9e45ba709473fe822834541b9e6R57-R58)`, `[[3]](diffhunk://#diff-a2fabd95425265415142c3c86689f38184ec420452092f7e5e5362582c0d97c7R40-R49)`, `[[4]](diffhunk://#diff-a2fabd95425265415142c3c86689f38184ec420452092f7e5e5362582c0d97c7L190-R198)`, `[[5]](diffhunk://#diff-a2fabd95425265415142c3c86689f38184ec420452092f7e5e5362582c0d97c7L214-R226)`)
- Ensured that all tile batch instantiations in `dailyTileList.dart` and `previewDailyTileList.dart` provide the correct end-of-day time. (`[[1]](diffhunk://#diff-4c609bc4e15fa72e467572c9ee1e62ef3158c229219c6e99dbd1f37b0382c317R331-R332)`, `[[2]](diffhunk://#diff-4c609bc4e15fa72e467572c9ee1e62ef3158c229219c6e99dbd1f37b0382c317R351-R352)`, `[[3]](diffhunk://#diff-4c609bc4e15fa72e467572c9ee1e62ef3158c229219c6e99dbd1f37b0382c317R376-R377)`, `[[4]](diffhunk://#diff-4c609bc4e15fa72e467572c9ee1e62ef3158c229219c6e99dbd1f37b0382c317R430-R431)`, `[[5]](diffhunk://#diff-1a5e8f126c79d6e737ff308d608fd840cd3cec879c06cad5cab40949d5161b3bL56-R55)`, `[[6]](diffhunk://#diff-1a5e8f126c79d6e737ff308d608fd840cd3cec879c06cad5cab40949d5161b3bL69-R71)`)

**Visual indication of end-of-day:**
- Modified `tileConnectorLayout.dart` to always append a `ReturnConnector` after the last tile, ensuring the end-of-day is visually marked even if there is no return travel data. (`[[1]](diffhunk://#diff-c13a69ab222ecdbe59c121ca8866df7f11cd207c727e49a023df290cfb903061R3)`, `[[2]](diffhunk://#diff-c13a69ab222ecdbe59c121ca8866df7f11cd207c727e49a023df290cfb903061R51-R52)`, `[[3]](diffhunk://#diff-c13a69ab222ecdbe59c121ca8866df7f11cd207c727e49a023df290cfb903061R185-R196)`)

**Code consistency and cleanup:**
- Refactored and formatted code for improved readability and consistency in affected files. (`[[1]](diffhunk://#diff-a2fabd95425265415142c3c86689f38184ec420452092f7e5e5362582c0d97c7L201-R214)`, `[[2]](diffhunk://#diff-a2fabd95425265415142c3c86689f38184ec420452092f7e5e5362582c0d97c7L223-R236)`, `[[3]](diffhunk://#diff-a2fabd95425265415142c3c86689f38184ec420452092f7e5e5362582c0d97c7L435-R449)`, `[[4]](diffhunk://#diff-a2fabd95425265415142c3c86689f38184ec420452092f7e5e5362582c0d97c7L495-R512)`, `[[5]](diffhunk://#diff-a2fabd95425265415142c3c86689f38184ec420452092f7e5e5362582c0d97c7L510-R527)`, `[[6]](diffhunk://#diff-1a5e8f126c79d6e737ff308d608fd840cd3cec879c06cad5cab40949d5161b3bL15-L25)`, `[[7]](diffhunk://#diff-1a5e8f126c79d6e737ff308d608fd840cd3cec879c06cad5cab40949d5161b3bL78-R85)`, `[[8]](diffhunk://#diff-1a5e8f126c79d6e737ff308d608fd840cd3cec879c06cad5cab40949d5161b3bL95)`)

These changes collectively improve the user experience by ensuring the end-of-day is accurately represented and easily adjustable throughout the daily tile list UI.